### PR TITLE
Project the input to the dimension of the transformer

### DIFF
--- a/e2_tts_pytorch/e2_tts.py
+++ b/e2_tts_pytorch/e2_tts.py
@@ -461,7 +461,6 @@ class E2TTS(Module):
 
         dim = transformer.dim
         self.dim = dim
-        self.to_pred = nn.Linear(dim, dim)
 
         self.embed_text = CharacterEmbed(dim, num_embeds = text_num_embeds, cond_drop_prob = cond_drop_prob)
 
@@ -478,6 +477,10 @@ class E2TTS(Module):
         # mel spec
 
         self.mel_spec = default(mel_spec_module, MelSpec(**mel_spec_kwargs))
+        num_channels = self.mel_spec.n_mel_channels
+ 
+        self.proj_in = nn.Linear(num_channels, dim)
+        self.to_pred = nn.Linear(dim, num_channels)
 
         # immiscible (diffusion / flow)
 
@@ -495,6 +498,7 @@ class E2TTS(Module):
         text: Int['b nt'] | None = None,
         drop_text_cond: bool | None = None
     ):
+        x = self.proj_in(x)
 
         if exists(text):
             x = self.embed_text(x, text, drop_text_cond = drop_text_cond)


### PR DESCRIPTION
This untangles the size of the transformer and the number of bins used in the spectrogram. I believe this is consistent with the paper based on these lines in Section 3.2:

`The architecture incorporated U-Net style skip connections, 24 layers, 16 attention heads, an embedding dimension of 1024, a linear layer dimension of 4096, and a dropout rate of 0.1. [...] We modeled the 100-dimensional log mel-filterbank features, [...]`

and it gives us the ability to scale the computation power of the transformer more easily.