### PR TITLE
Make the default mel spec compatible with vocos

### DIFF
--- a/e2_tts_pytorch/e2_tts.py
+++ b/e2_tts_pytorch/e2_tts.py
@@ -97,34 +97,33 @@ def maybe_masked_mean(
 
 # to mel spec
 
+
 class MelSpec(Module):
     def __init__(
         self,
         filter_length = 1024,
         hop_length = 256,
         win_length = 1024,
-        n_mel_channels = 80,
-        mel_fmin = 0,
-        mel_fmax = 8000,
-        sampling_rate = 22050,
+        n_mel_channels = 100,
+        sampling_rate = 24_000,
         normalize = False,
-        power = 2,
-        norm = "slaney"
+        power = 1,
+        norm = None,
+        center = True,
     ):
         super().__init__()
         self.n_mel_channels = n_mel_channels
 
         self.mel_stft = torchaudio.transforms.MelSpectrogram(
-            n_fft=filter_length,
-            hop_length=hop_length,
-            win_length=win_length,
-            power=power,
-            normalized=normalize,
-            sample_rate=sampling_rate,
-            f_min=mel_fmin,
-            f_max=mel_fmax,
-            n_mels=n_mel_channels,
-            norm=norm,
+            sample_rate = sampling_rate,
+            n_fft = filter_length,
+            win_length = win_length,
+            hop_length = hop_length,
+            n_mels = n_mel_channels,
+            power = power,
+            center = center,
+            normalized = normalize,
+            norm = norm,
         )
 
         self.register_buffer('dummy', torch.tensor(0), persistent = False)

--- a/e2_tts_pytorch/trainer.py
+++ b/e2_tts_pytorch/trainer.py
@@ -61,7 +61,7 @@ class HFDataset(Dataset):
     def __init__(
         self,
         hf_dataset: Dataset,
-        target_sample_rate = 22050,
+        target_sample_rate = 24_000,
         hop_length = 256
     ):
         self.data = hf_dataset


### PR DESCRIPTION
[Vocos](https://huggingface.co/charactr/vocos-mel-24khz) is a really small and fast vocoder — we previously used it for Voicebox as it handles both mel spec and Encodec-based vocoding.

This change uses their particular mel spec recipe as the default (a seemingly common spec for TTS systems), so you can `pip install vocos` and then pass `vocos.decode` to the sampling function and get audio output.

This isn't strictly necessary to take, but I thought it might be useful for folks who are hoping to train a working network 'out of the box' without needing to think about the transform!