### PR TITLE
add mel spectrogram prediction to tensorboard

### DIFF
--- a/e2_tts_pytorch/e2_tts.py
+++ b/e2_tts_pytorch/e2_tts.py
@@ -745,4 +745,4 @@ class E2TTS(Module):
 
         loss = loss[rand_span_mask]
 
-        return loss.mean()
+        return loss.mean(), cond, pred


### PR DESCRIPTION
I'm adding this code to inspect the training dynamics easily by adding the mel spectrograms predictions in the tensorboard.

![image](https://github.com/user-attachments/assets/229f3ea6-a12f-4978-bf61-a22c8c9e5cd2)
